### PR TITLE
Description of package for search results.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "language-restructuredtext",
   "version": "0.1.0",
   "private": true,
-  "description": "A short description of your package",
+  "description": "RestructuredText Language Support",
   "repository": "https://github.com/Lukasa/language-restructuredtext",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Right now the description that comes up when searching for this package is the default, boring one.

![screen shot 2014-05-20 at 11 12 52 am](https://cloud.githubusercontent.com/assets/836375/3030521/04405ebe-e042-11e3-9080-41c1bc720ef1.png)

This changes that!

Ok, it's not any less boring but it does what its intended to do.
