### PR TITLE
Highlight code blocks as their native language.

### DIFF
--- a/grammars/restructuredtext.cson
+++ b/grammars/restructuredtext.cson
@@ -323,6 +323,19 @@
         ]
       }
       {
+        'begin': '^([ \\t]*)\\.\\.\\scode-block::\\s(shell|(ba|k)?sh)\\s*$'
+        'captures':
+          '2':
+            'name': 'entity.name.directive.restructuredtext'
+        'end': '^(?!\\1[ \\t])(?=\\S+)'
+        'contentName': 'source.shell'
+        'patterns': [
+          {
+            'include': 'source.shell'
+          }
+        ]
+      }
+      {
         'begin': '^([ \\t]*)\\.\\.\\scode-block::\\s(py(thon)?|sage)\\s*$'
         'captures':
           '2':


### PR DESCRIPTION
See #3. This is basically cargo-culted entirely from the way [the GFM language does it](https://github.com/atom/language-gfm/blob/master/grammars/gfm.cson#L248-L264).
## Language List

ReStructured Text uses [Pygments](http://pygments.org/docs/lexers/) for syntax highlighting, while the languages Atom/GFM support can be lifted from [the GFM plugin](https://github.com/atom/language-gfm/blob/master/grammars/gfm.cson#L146-L504).
- [x] Pygments: `coffee-?script` => Atom: `source.coffee`
- [x] Pygments: `js|javascript` => Atom: `source.js`
- [x] Pygments: `json` => Atom: `source.json`
- [x] Pygments: `css` => Atom: `source.css`
- [ ] Atom: `source.less`
- [x] Pygments: `xml` => Atom: `source.xml`
- [x] Pygments: `rb|[rd]uby` => Atom: `source.ruby`
- [x] Pygments: `java` => Atom: `source.java`
- [x] Pygments: `erlang` => Atom: `source.erlang`
- [x] Pygments: `csharp|c#` => Atom: `source.cs`
- [x] Pygments: `php[3-5]?` => Atom: `source.php`
- [x] Atom: `source.shell` _(Maybe the bash lexer?)_
- [x] Pygments: `py(thon)?|sage` => Atom: `source.python`
- [x] Pygments: `objective-?c||obj-?c` => Atom: `source.objc`
- [ ] Atom: `source.basic` => _(is this VB.net?)_
- [x] Pygments: `yaml` => Atom: `source.yaml`
