### PR TITLE
Fixed-size underline for section snippets (Fixes #5)

### DIFF
--- a/snippets/language-restructuredtext.cson
+++ b/snippets/language-restructuredtext.cson
@@ -7,10 +7,10 @@
     'body': '\n\\`${1:Title}<${2:http://link}>\\`_'
   'section 1':
     'prefix': 'sec'
-    'body': '${1:subsection name}\n${1/(.)|\\s/(?1:=:=)/g}\n$0'
+    'body': '${1:subsection name}\n================$0\n'
   'section 2':
     'prefix': 'subs'
-    'body': '${1:subsection name}\n${1/(.)|\\s/(?1:*:*)/g}\n$0'
+    'body': '${1:subsection name}\n****************$0\n'
   'section 3':
     'prefix': 'sss'
-    'body': '${1:subsection name}\n${1/(.)|\\s/(?1:-:-)/g}\n$0'
+    'body': '${1:subsection name}\n----------------$0\n'


### PR DESCRIPTION
Moved the last tab-index before the last new-line, allowing to delete or add delimitors after having written the section's title.