### PR TITLE
modify scope

### DIFF
--- a/grammars/restructuredtext.cson
+++ b/grammars/restructuredtext.cson
@@ -613,4 +613,4 @@
         'name': 'entity.name.tag.restructuredtext'
       }
     ]
-'scopeName': 'gfm.restructuredtext'
+'scopeName': 'text.restructuredtext'

--- a/grammars/restructuredtext.cson
+++ b/grammars/restructuredtext.cson
@@ -613,4 +613,4 @@
         'name': 'entity.name.tag.restructuredtext'
       }
     ]
-'scopeName': 'text.restructuredtext'
+'scopeName': 'text.restructuredtext source.gfm.restructuredtext'

--- a/settings/language-restructuredtext.cson
+++ b/settings/language-restructuredtext.cson
@@ -1,4 +1,4 @@
-'.text.restructuredtext':
+'.text.restructuredtext .source.gfm.restructuredtext':
   'editor':
     'commentStart': '.. '
     'increaseIndentPattern': '::\\s*$'

--- a/snippets/language-restructuredtext.cson
+++ b/snippets/language-restructuredtext.cson
@@ -1,4 +1,4 @@
-'.text.restructuredtext':
+'.text.restructuredtext .source.gfm.restructuredtext':
   'image':
     'prefix': 'image'
     'body': '.. image:: ${1:path}\n$0'

--- a/snippets/language-restructuredtext.cson
+++ b/snippets/language-restructuredtext.cson
@@ -1,4 +1,4 @@
-'.gfm.restructuredtext':
+'.text.restructuredtext':
   'image':
     'prefix': 'image'
     'body': '.. image:: ${1:path}\n$0'


### PR DESCRIPTION
At first, I wanted to use dual scopes `.text.restructuredtext .source.gfm.restructuredtext`, but then I noticed rst files are perfectly highlighted when using `.text.restructuredtext`. In fact, when open a rst file and change the scope to Markdown, you will notice the lack of any highlighting.

![screen shot 2015-09-08 at 09 16 29](https://cloud.githubusercontent.com/assets/1504938/9728730/5ddd2d5a-560a-11e5-800f-d29d4eff8b6d.png)
*fig 1a)* GitHub Markdown scope using Atom Dark syntax theme

![screen shot 2015-09-08 at 09 16 35](https://cloud.githubusercontent.com/assets/1504938/9728732/62136272-560a-11e5-85e6-637e9ed43fb2.png)
*fig 1b)* reStructuredText scope using Atom Dark syntax theme

For emphasis, let's use a more colorful theme:

![screen shot 2015-09-08 at 09 16 52](https://cloud.githubusercontent.com/assets/1504938/9728754/7f1651c2-560a-11e5-9385-80b2e1d7bcff.png)
*fig 2a)* GitHub Markdown scope using Hopscotch syntax theme

![screen shot 2015-09-08 at 09 16 45](https://cloud.githubusercontent.com/assets/1504938/9728759/86682dc4-560a-11e5-894b-09cf0bb9a932.png)
*fig 2b)* reStructuredText scope using Hopscotch syntax theme

So it seems to be safe to use a more appropriate scope for reStructuredText.