### PR TITLE
Fix errors with parsing indented code-blocks

### DIFF
--- a/grammars/restructuredtext.cson
+++ b/grammars/restructuredtext.cson
@@ -26,6 +26,24 @@
         'include': '#raw-blocks'
       }
       {
+        'include': '#inlines'
+      }
+      {
+        'include': '#tags'
+      }
+      {
+        'include': '#tables'
+      }
+      {
+        'include': '#headings'
+      }
+      {
+        'include': '#comments'
+      }
+    ]
+  'inlines':
+    'patterns': [
+      {
         'include': '#emphasis'
       }
       {
@@ -114,18 +132,6 @@
       {
         'include': '#citations'
       }
-      {
-        'include': '#tags'
-      }
-      {
-        'include': '#tables'
-      }
-      {
-        'include': '#headings'
-      }
-      {
-        'include': '#comments'
-      }
     ]
   'citations':
     'patterns': [
@@ -197,7 +203,7 @@
         'captures':
           '2':
             'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\1[ \\t])(?=\\S+)'
+        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
         'contentName': 'source.embedded.coffee'
         'patterns': [
           {
@@ -210,7 +216,7 @@
         'captures':
           '2':
             'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\1[ \\t])(?=\\S+)'
+        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
         'contentName': 'source.embedded.js'
         'patterns': [
           {
@@ -223,7 +229,7 @@
         'captures':
           '2':
             'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\1[ \\t])(?=\\S+)'
+        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
         'contentName': 'source.embedded.json'
         'patterns': [
           {
@@ -236,7 +242,7 @@
         'captures':
           '2':
             'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\1[ \\t])(?=\\S+)'
+        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
         'contentName': 'source.embedded.css'
         'patterns': [
           {
@@ -249,7 +255,7 @@
         'captures':
           '2':
             'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\1[ \\t])(?=\\S+)'
+        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
         'contentName': 'source.embedded.xml'
         'patterns': [
           {
@@ -262,7 +268,7 @@
         'captures':
           '2':
             'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\1[ \\t])(?=\\S+)'
+        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
         'contentName': 'source.embedded.ruby'
         'patterns': [
           {
@@ -275,7 +281,7 @@
         'captures':
           '2':
             'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\1[ \\t])(?=\\S+)'
+        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
         'contentName': 'source.embedded.java'
         'patterns': [
           {
@@ -288,7 +294,7 @@
         'captures':
           '2':
             'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\1[ \\t])(?=\\S+)'
+        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
         'contentName': 'source.embedded.erlang'
         'patterns': [
           {
@@ -301,7 +307,7 @@
         'captures':
           '2':
             'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\1[ \\t])(?=\\S+)'
+        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
         'contentName': 'source.embedded.cs'
         'patterns': [
           {
@@ -314,7 +320,7 @@
         'captures':
           '2':
             'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\1[ \\t])(?=\\S+)'
+        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
         'contentName': 'source.embedded.php'
         'patterns': [
           {
@@ -327,7 +333,7 @@
         'captures':
           '2':
             'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\1[ \\t])(?=\\S+)'
+        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
         'contentName': 'source.embedded.shell'
         'patterns': [
           {
@@ -340,7 +346,7 @@
         'captures':
           '2':
             'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\1[ \\t])(?=\\S+)'
+        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
         'contentName': 'source.embedded.python'
         'patterns': [
           {
@@ -353,7 +359,7 @@
         'captures':
           '2':
             'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\1[ \\t])(?=\\S+)'
+        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
         'contentName': 'source.embedded.objc'
         'patterns': [
           {
@@ -366,7 +372,7 @@
         'captures':
           '2':
             'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\1[ \\t])(?=\\S+)'
+        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
         'contentName': 'source.embedded.yaml'
         'patterns': [
           {
@@ -562,13 +568,19 @@
   'raw-blocks':
     'patterns': [
       {
-        'begin': '(::)$'
+        'begin': '^(?!\\s*\\.\\.\\s\\w+)(\\s*)(.*)(::)$'
         'beginCaptures':
-          '1':
+          '2':
+            'patterns': [
+              {
+                'include': '#inlines'
+              }
+            ]
+          '3':
             'name': 'punctuation.section.raw.restructuredtext'
         'comment': 'Literal Blocks'
         'contentName': 'meta.raw.block.restructuredtext'
-        'end': '^(?=\\S)'
+        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
         'patterns': [
           {
             'include': '#raw-blocks-inner'
@@ -609,7 +621,7 @@
           '2':
             'name': 'punctuation.definition.field.restructuredtext'
         'comment': 'tags (and field lists'
-        'match': '(:)[A-z][A-z0-9  =\\s\\t_.]*(:)'
+        'match': '(:)[A-Za-z][\\w\\s=.]*(:)'
         'name': 'entity.name.tag.restructuredtext'
       }
     ]


### PR DESCRIPTION
Last night I begun "translating" a document into reStructuredText, and I noticed an issue (which was [already reported](https://github.com/Lukasa/language-restructuredtext/issues/22)). I fixed it for you.

### Notes:
- The fix for indented `::` blocks prevented any inline patterns (such as `*this*` or `this__`) from being picked up in a line which ended in `::`:  
<img src="https://cloud.githubusercontent.com/assets/2346707/15496410/59529dca-21d8-11e6-9fb0-37e620d27a75.png" width="463" alt="Figure 1" />  
This was remedied by grouping all inline-patterns into a new group (`#inlines`) and embedding it within the respective `beginCaptures` group:  
<img src="https://cloud.githubusercontent.com/assets/2346707/15496525/09d64106-21d9-11e6-8495-d0d6976a4aed.png" width="483" alt="Figure 2" />  
The reason for this is because when TextMate starts a match, it doesn't apply other matches to its content unless it's told to (with a `patterns` statement).  
<br/>
I'm pointing this out in case it helps explain future (or past) matching errors of a similar nature.  
<br/>
- The pattern to match field-names used `(:)[A-z][A-z0-9  =\\s\\t_.]*(:)` as a matching sequence. I've amended it so it's now `(:)[A-Za-z][\\w\\s=.]*(:)` instead. Because of ASCII ordering, `[A‑z]` actually matches this:<br/><br/>
<pre><code>ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_\`abcdefghijklmnopqrstuvwxyz</code></pre>
Note what's in-between; I doubt `\` and <code>`</code> are accepted in field-name identifiers.