### PR TITLE
reStructure entire grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-# ReStructured Text language support in Atom
+# reStructuredText language support in Atom
 
-Adds syntax highlighting and snippets to ReStructuredText file in Atom.
+Adds snippets and syntax highlighting for reStructuredText files (`.rst`/`.rest`).
 
-Originally [converted](https://atom.io/docs/latest/converting-a-text-mate-bundle) from the [ReStructuredText TextMate bundle](https://github.com/textmate/restructuredtext.tmbundle).
+Originally [converted](https://atom.io/docs/latest/converting-a-text-mate-bundle) from the [reStructuredText TextMate bundle](https://github.com/textmate/restructuredtext.tmbundle).
 
 Contributions are greatly appreciated.
+
+## Related links
+- [Quick language reference](http://docutils.sourceforge.net/docs/user/rst/quickref.html)
+- [Package at Atom.io](https://atom.io/packages/language-restructuredtext)

--- a/demo.rst
+++ b/demo.rst
@@ -1,5 +1,12 @@
 .. This is a comment. Note how any initial comments are moved by
    transforms to after the document title, subtitle, and docinfo.
+   
+   Separate paragraphs are okay too, as long as they're indented.
+
+..
+   Comments can be started on their own lines too (like this one).
+   Make sure there's no empty line between the ".." and the first
+   paragraph!
 
 ================================
  reStructuredText Demonstration

--- a/grammars/restructuredtext.cson
+++ b/grammars/restructuredtext.cson
@@ -1,689 +1,923 @@
-'comment': 'Syntax highlighting for reStructuredText: http://docutils.sourceforge.net'
-'fileTypes': [
-  'rst'
-  'rest'
-]
-'name': 'reStructuredText'
-'patterns': [
-  {
-    'include': '#block-comments'
-  }
-  
-  {
-    'begin': '^([ \\t]*)(?!\\.\\.)(?=\\S)'
-    'contentName': 'meta.paragraph.restructuredtext'
-    'end': '^(?!\\1)'
-    'patterns': [
-      {
-        'include': '#all'
-      }
-    ]
-  }
-]
-'repository':
-  'all':
-    'patterns': [
-      {
-        'include': '#directives'
-      }
-      {
-        'include': '#raw-blocks'
-      }
-      {
-        'include': '#inlines'
-      }
-      {
-        'include': '#tags'
-      }
-      {
-        'include': '#tables'
-      }
-      {
-        'include': '#doctests'
-      }
-      {
-        'include': '#headings'
-      }
-      {
-        'include': '#comments'
-      }
-    ]
-  'inlines':
-    'patterns': [
-      {
-        'include': '#emphasis'
-      }
-      {
-        'include': '#link-def'
-      }
-      {
-        'captures':
-          '1':
-            'name': 'punctuation.definition.substitution.restructuredtext'
-        'comment': 'substitution'
-        'match': '(?<!\\\\)(\\|)[^|]+(?<!\\\\)(\\|_{0,2})'
-        'name': 'markup.underline.substitution.restructuredtext'
-      }
-      {
-        'begin': '``'
-        'captures':
-          '0':
-            'name': 'punctuation.definition.raw.restructuredtext'
-        'comment': 'inline literal'
-        'end': '``((?=[^`\\w\\d])|$)'
-        'name': 'markup.raw.restructuredtext'
-      }
-      {
-        'captures':
-          '1':
-            'name': 'punctuation.definition.intepreted.restructuredtext'
-          '2':
-            'name': 'punctuation.definition.intepreted.restructuredtext'
-        'comment': 'intepreted text - single line'
-        'match': '(`)[^`]+(`)(?!_)'
-        'name': 'markup.other.command.restructuredtext'
-      }
-      {
-        'captures':
-          '1':
-            'name': 'punctuation.definition.link.restructuredtext'
-          '2':
-            'name': 'markup.underline.link.restructuredtext'
-        'comment': 'anonymous links __ url'
-        'match': '\\s*(__)\\s+(.+)'
-        'name': 'meta.link.restructuredtext'
-      }
-      {
-        'include': '#link-reference'
-      }
-      {
-        'begin': '(:)([-A-z0-9_.]*)(:)(`)'
-        'beginCaptures':
-          '1':
-            'name': 'punctuation.definition.intepreted.restructuredtext'
-          '2':
-            'name': 'entity.name.role.restructuredtext'
-          '3':
-            'name': 'punctuation.definition.intepreted.restructuredtext'
-          '4':
-            'name': 'punctuation.definition.intepreted.restructuredtext'
-        'comment': 'intepreted text - multiline with role'
-        'contentName': 'string.other.interpreted.restructuredtext'
-        'end': '(`)'
-        'endCaptures':
-          '1':
-            'name': 'punctuation.definition.intepreted.restructuredtext'
-        'name': 'markup.other.command.restructuredtext'
-      }
-      {
-        'captures':
-          '1':
-            'name': 'punctuation.definition.link.restructuredtext'
-          '2':
-            'name': 'string.other.link.title.restructuredtext'
-          '3':
-            'name': 'punctuation.definition.location.restructuredtext'
-          '4':
-            'name': 'markup.underline.link.restructuredtext'
-          '5':
-            'name': 'punctuation.definition.location.restructuredtext'
-          '6':
-            'name': 'punctuation.definition.link.restructuredtext'
-        'comment': 'links `...`_ '
-        'match': '(`)([^<`]+)\\s+(<)(.*?)(>)(`_)'
-        'name': 'meta.link.inline.restructuredtext'
-      }
-      {
-        'include': '#footnotes'
-      }
-      {
-        'include': '#citations'
-      }
-    ]
-  'citations':
-    'patterns': [
-      {
-        'captures':
-          '1':
-            'name': 'punctuation.definition.link.restructuredtext'
-          '2':
-            'name': 'constant.other.citation.link.restructuredtext'
-          '3':
-            'name': 'punctuation.definition.constant.restructuredtext'
-          '4':
-            'name': 'punctuation.definition.constant.restructuredtext'
-          '5':
-            'name': 'punctuation.definition.constant.restructuredtext'
-          '6':
-            'name': 'string.other.citation.restructuredtext'
-        'comment': 'replacement'
-        'match': '^(\\.\\.)\\s+((\\[)[A-z][A-z0-9]*(\\]))(_)\\s+(.*)'
-        'name': 'meta.link.citation.def.restructuredtext'
-      }
-      {
-        'captures':
-          '1':
-            'name': 'constant.other.citation.link.restructuredtext'
-          '2':
-            'name': 'punctuation.definition.constant.restructuredtext'
-          '3':
-            'name': 'punctuation.definition.constant.restructuredtext'
-          '4':
-            'name': 'punctuation.definition.constant.restructuredtext'
-        'comment': 'citation reference'
-        'match': '((\\[)[A-z][A-z0-9_-]*(\\]))(_)'
-        'name': 'meta.link.citation.restructuredtext'
-      }
-    ]
-  'block-comments':
-    'patterns': [
-      {
-        'name': 'comment.block.empty-start.double-dot.restructuredtext'
-        'begin': '^(\\.\\.)[\\t ]*$\\n?'
-        'end': "^(?<=\\G)\\s*$\\n?|^(?=\\S)"
-        'beginCaptures':
-          '1':
-            'name': 'punctuation.definition.comment.restructuredtext'
-        'patterns': [
-          {
-            'begin': "^(\\s+).*?\\S+\\s*$\\n"
-            'end': "^\\s*$\\n|^(?=\\S)"
-          }
-        ]
-      }
-      
-      {
-        'name': 'comment.block.empty-start.double-dot.restructuredtext'
-        'begin': '^([\\t ]*)(\\.\\.)[\\t ]*$\\n?'
-        'end': "^(?!\\1\\s*\\S)|^(?<!\\G)\\s*$\\n?|^(?=\\S)"
-        'beginCaptures':
-          '2':
-            'name': 'punctuation.definition.comment.restructuredtext'
-        'patterns': [
-          {
-            'begin': "^(\\s+).*?\\S+\\s*$\\n"
-            'end': "^\\s*$\\n|^\\s*(?=\\S)"
-          }
-        ]
-      }
-      
-      {
-        'name': 'comment.block.double-dot.restructuredtext'
-        'begin': '^(\\s*)(\\.\\.)(?=\\s|$)'
-        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
-      }
-    ]
-  'comments':
-    'patterns': [
-      {
-        'begin': "^([\\t ]*)(\\.\\.)(?=\\s|$)"
-        'end': "^(?!\\1[\\t\\s]+\\S|\\s*$)|^(?=\\S)"
-        'beginCaptures':
-          '2':
-            'name': 'punctuation.definition.comment.restructuredtext'
-        'name': "comment.block.double-dot.restructuredtext"
-      }
-    ]
-  'directives':
-    'patterns': [
-      {
-        'begin': '^([ \\t]*)((\\.\\.)\\sraw(::)) html'
-        'captures':
-          '2':
-            'name': 'meta.directive.restructuredtext'
-          '3':
-            'name': 'punctuation.definition.directive.restructuredtext'
-          '4':
-            'name': 'punctuation.separator.key-value.restructuredtext'
-        'comment': 'directives.html'
-        'end': '^(?!\\1[ \\t])'
-        'patterns': [
-          {
-            'include': 'text.html.basic'
-          }
-        ]
-      }
-      {
-        'begin': '^([ \\t]*)\\.\\.\\scode-block::\\s(coffee-?script)\\s*$'
-        'captures':
-          '2':
-            'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
-        'contentName': 'source.embedded.coffee'
-        'patterns': [
-          {
-            'include': 'source.coffee'
-          }
-        ]
-      }
-      {
-        'begin': '^([ \\t]*)\\.\\.\\scode-block::\\s(js|javascript)\\s*$'
-        'captures':
-          '2':
-            'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
-        'contentName': 'source.embedded.js'
-        'patterns': [
-          {
-            'include': 'source.js'
-          }
-        ]
-      }
-      {
-        'begin': '^([ \\t]*)\\.\\.\\scode-block::\\s(json)\\s*$'
-        'captures':
-          '2':
-            'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
-        'contentName': 'source.embedded.json'
-        'patterns': [
-          {
-            'include': 'source.json'
-          }
-        ]
-      }
-      {
-        'begin': '^([ \\t]*)\\.\\.\\scode-block::\\s(css)\\s*$'
-        'captures':
-          '2':
-            'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
-        'contentName': 'source.embedded.css'
-        'patterns': [
-          {
-            'include': 'source.css'
-          }
-        ]
-      }
-      {
-        'begin': '^([ \\t]*)\\.\\.\\scode-block::\\s(xml)\\s*$'
-        'captures':
-          '2':
-            'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
-        'contentName': 'source.embedded.xml'
-        'patterns': [
-          {
-            'include': 'source.xml'
-          }
-        ]
-      }
-      {
-        'begin': '^([ \\t]*)\\.\\.\\scode-block::\\s(ruby)\\s*$'
-        'captures':
-          '2':
-            'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
-        'contentName': 'source.embedded.ruby'
-        'patterns': [
-          {
-            'include': 'source.ruby'
-          }
-        ]
-      }
-      {
-        'begin': '^([ \\t]*)\\.\\.\\scode-block::\\s(java)\\s*$'
-        'captures':
-          '2':
-            'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
-        'contentName': 'source.embedded.java'
-        'patterns': [
-          {
-            'include': 'source.java'
-          }
-        ]
-      }
-      {
-        'begin': '^([ \\t]*)\\.\\.\\scode-block::\\s(erlang)\\s*$'
-        'captures':
-          '2':
-            'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
-        'contentName': 'source.embedded.erlang'
-        'patterns': [
-          {
-            'include': 'source.erlang'
-          }
-        ]
-      }
-      {
-        'begin': '^([ \\t]*)\\.\\.\\scode-block::\\s(csharp|c#)\\s*$'
-        'captures':
-          '2':
-            'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
-        'contentName': 'source.embedded.cs'
-        'patterns': [
-          {
-            'include': 'source.cs'
-          }
-        ]
-      }
-      {
-        'begin': '^([ \\t]*)\\.\\.\\scode-block::\\s(php[3-5]?)\\s*$'
-        'captures':
-          '2':
-            'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
-        'contentName': 'source.embedded.php'
-        'patterns': [
-          {
-            'include': 'source.php'
-          }
-        ]
-      }
-      {
-        'begin': '^([ \\t]*)\\.\\.\\scode-block::\\s(shell|(ba|k)?sh)\\s*$'
-        'captures':
-          '2':
-            'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
-        'contentName': 'source.embedded.shell'
-        'patterns': [
-          {
-            'include': 'source.shell'
-          }
-        ]
-      }
-      {
-        'begin': '^([ \\t]*)\\.\\.\\scode-block::\\s(py(thon)?|sage)\\s*$'
-        'captures':
-          '2':
-            'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
-        'contentName': 'source.embedded.python'
-        'patterns': [
-          {
-            'include': 'source.python'
-          }
-        ]
-      }
-      {
-        'begin': '^([ \\t]*)\\.\\.\\scode-block::\\s(objective-?c|obj-?c)\\s*$'
-        'captures':
-          '2':
-            'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
-        'contentName': 'source.embedded.objc'
-        'patterns': [
-          {
-            'include': 'source.objc'
-          }
-        ]
-      }
-      {
-        'begin': '^([ \\t]*)\\.\\.\\scode-block::\\s(yaml)\\s*$'
-        'captures':
-          '2':
-            'name': 'entity.name.directive.restructuredtext'
-        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
-        'contentName': 'source.embedded.yaml'
-        'patterns': [
-          {
-            'include': 'source.yaml'
-          }
-        ]
-      }
-      {
-        'captures':
-          '1':
-            'name': 'punctuation.definition.directive.restructuredtext'
-          '2':
-            'name': 'support.directive.restructuredtext'
-          '3':
-            'name': 'punctuation.separator.key-value.restructuredtext'
-        'comment': 'directives'
-        'match': '(\\.\\.)\\s([A-z][-A-z0-9_]+)(::)\\s*$'
-        'name': 'meta.other.directive.restructuredtext'
-      }
-      {
-        'captures':
-          '1':
-            'name': 'punctuation.definition.directive.restructuredtext'
-          '2':
-            'name': 'support.directive.restructuredtext'
-          '3':
-            'name': 'punctuation.separator.key-value.restructuredtext'
-          '4':
-            'name': 'entity.name.directive.restructuredtext'
-        'comment': 'directives with arguments'
-        'match': '(\\.\\.)\\s([A-z][-A-z0-9_]+)(::)\\s+(.+?)\\s*$'
-        'name': 'meta.other.directive.restructuredtext'
-      }
-    ]
-  'emphasis':
-    'patterns': [
-      {
-        'captures':
-          '1':
-            'name': 'punctuation.definition.bold.restructuredtext'
-          '2':
-            'name': 'punctuation.definition.bold.restructuredtext'
-        'match': '(\\*\\*)[^\\*\\s][^*]*(\\*\\*)'
-        'name': 'markup.bold.restructuredtext'
-      }
-      {
-        'captures':
-          '1':
-            'name': 'punctuation.definition.italic.restructuredtext'
-          '2':
-            'name': 'punctuation.definition.italic.restructuredtext'
-        'match': '(?<!\\\\)(\\*)[^\\*\\s][^*]*(?<!\\\\)(\\*)'
-        'name': 'markup.italic.restructuredtext'
-      }
-    ]
-  'footnotes':
-    'patterns': [
-      {
-        'captures':
-          '1':
-            'name': 'punctuation.definition.link.restructuredtext'
-          '2':
-            'name': 'constant.other.footnote.link.restructuredtext'
-          '3':
-            'name': 'punctuation.definition.constant.restructuredtext'
-          '6':
-            'name': 'punctuation.definition.constant.restructuredtext'
-          '7':
-            'name': 'punctuation.definition.constant.restructuredtext'
-          '8':
-            'name': 'string.other.footnote.restructuredtext'
-        'comment': 'replacement'
-        'match': '^(\\.\\.)\\s+((\\[)(((#?)[^]]*?)|\\*)(\\]))\\s+(.*)'
-        'name': 'meta.link.footnote.def.restructuredtext'
-      }
-      {
-        'captures':
-          '1':
-            'name': 'constant.other.footnote.link'
-          '2':
-            'name': 'punctuation.definition.constant.restructuredtext'
-          '3':
-            'name': 'punctuation.definition.constant.restructuredtext'
-          '4':
-            'name': 'punctuation.definition.constant.restructuredtext'
-        'comment': 'footnote reference: [0]_'
-        'match': '((\\[)[0-9]+(\\]))(_)'
-        'name': 'meta.link.footnote.numeric.restructuredtext'
-      }
-      {
-        'captures':
-          '1':
-            'name': 'constant.other.footnote.link'
-          '2':
-            'name': 'punctuation.definition.constant.restructuredtext'
-          '3':
-            'name': 'punctuation.definition.constant.restructuredtext'
-          '4':
-            'name': 'punctuation.definition.constant.restructuredtext'
-        'comment': 'footnote reference [#]_ or [#foo]_'
-        'match': '((\\[#)[A-z0-9_]*(\\]))(_)'
-        'name': 'meta.link.footnote.auto.restructuredtext'
-      }
-      {
-        'captures':
-          '1':
-            'name': 'constant.other.footnote.link.restructuredtext'
-          '2':
-            'name': 'punctuation.definition.constant.restructuredtext'
-          '3':
-            'name': 'punctuation.definition.constant.restructuredtext'
-          '4':
-            'name': 'punctuation.definition.constant.restructuredtext'
-        'comment': 'footnote reference [*]_'
-        'match': '((\\[)\\*(\\]))(_)'
-        'name': 'meta.link.footnote.symbol.auto.restructuredtext'
-      }
-    ]
-  'headings':
-    'patterns': [
-      {
-        'captures':
-          '1':
-            'name': 'punctuation.definition.heading.restructuredtext'
-        'match': '(^(=|-|~|`|#|"|\\^|\\+|\\*|\\:|\\.|\'|_){3,}$){1,1}?'
-        'name': 'markup.heading.restructuredtext'
-      }
-    ]
-  'link-def':
-    'patterns': [
-      {
-        'captures':
-          '1':
-            'name': 'punctuation.definition.link.restructuredtext'
-          '2':
-            'name': 'punctuation.definition.string.restructuredtext'
-          '3':
-            'name': 'string.other.link.title.restructuredtext'
-          '4':
-            'name': 'punctuation.separator.key-value.restructuredtext'
-          '5':
-            'name': 'markup.underline.link.restructuredtext'
-        'comment': 'replacement'
-        'match': '(\\.\\.)\\s+(_)([-.\\d\\w\\s()/]+)(:)\\s+(.*)'
-        'name': 'meta.link.reference.def.restructuredtext'
-      }
-      {
-        'captures':
-          '1':
-            'name': 'punctuation.definition.link.restructuredtext'
-          '2':
-            'name': 'punctuation.definition.string.restructuredtext'
-          '3':
-            'name': 'string.other.link.title.restructuredtext'
-          '4':
-            'name': 'punctuation.separator.key-value.restructuredtext'
-          '5':
-            'name': 'markup.underline.link.restructuredtext'
-        'comment': 'replacement'
-        'match': '(\\.\\.)\\s+(_`)([^`]+)(`:)\\s+(.*)'
-        'name': 'meta.link.reference.def.restructuredtext'
-      }
-    ]
-  'link-reference':
-    'patterns': [
-      {
-        'captures':
-          '1':
-            'name': 'string.other.link.title.restructuredtext'
-          '2':
-            'name': 'punctuation.definition.link.restructuredtext'
-        'match': '\\b([-.:+_\\d\\w]+)(_)\\b'
-        'name': 'meta.link.reference'
-      }
-      {
-        'begin': '(`)'
-        'beginCaptures':
-          '1':
-            'name': 'punctuation.definition.link.restructuredtext'
-        'end': '(`_)'
-        'endCaptures':
-          '1':
-            'name': 'punctuation.definition.link.restructuredtext'
-        'name': 'meta.link.reference'
-        'patterns': [
-          {
-            'match': '[^`]+'
-            'name': 'string.other.link.title.restructuredtext'
-          }
-        ]
-      }
-    ]
-  'raw-blocks':
-    'patterns': [
-      {
-        'begin': '^(?!\\s*\\.\\.\\s\\w+)(\\s*)(.*)(::)$'
-        'beginCaptures':
-          '2':
-            'patterns': [
-              {
-                'include': '#inlines'
-              }
-            ]
-          '3':
-            'name': 'punctuation.section.raw.restructuredtext'
-        'comment': 'Literal Blocks'
-        'contentName': 'meta.raw.block.restructuredtext'
-        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
-        'patterns': [
-          {
-            'include': '#raw-blocks-inner'
-          }
-        ]
-      }
-    ]
-  'raw-blocks-inner':
-    'patterns': [
-      {
-        'match': '.+'
-        'name': 'markup.raw.inner.restructuredtext'
-      }
-    ]
-  'doctests':
-    'patterns': [
-      {
-        'name': 'meta.doctest.restructuredtext'
-        'begin': '^(\\s*)(>>>)\\s+(.*)$\\n'
-        'end': '^\\s*$|^(?=\\1>>> )|^(?=>>>)|^(?!\\1)\\s+\\S'
-        'contentName': 'markup.raw.restructuredtext'
-        'beginCaptures':
-          '2':
-            'name': 'punctuation.separator.prompt.doctest.restructuredtext'
-          '3':
-            'patterns': [
-              'include': 'source.python'
-            ]
-      }
-    ]
-  'tables':
-    'patterns': [
-      {
-        'captures':
-          '0':
-            'name': 'punctuation.definition.table.restructuredtext'
-        'match': '\\+-[+-]+'
-        'name': 'markup.other.table.restructuredtext'
-      }
-      {
-        'captures':
-          '0':
-            'name': 'punctuation.definition.table.restructuredtext'
-        'match': '\\+=[+=]+'
-        'name': 'markup.other.table.restructuredtext'
-      }
-    ]
-  'tags':
-    'patterns': [
-      {
-        'captures':
-          '1':
-            'name': 'punctuation.definition.field.restructuredtext'
-          '2':
-            'name': 'punctuation.definition.field.restructuredtext'
-        'comment': 'tags (and field lists'
-        'match': '(:)[A-Za-z][\\w\\s=.]*(:)'
-        'name': 'entity.name.tag.restructuredtext'
-      }
-    ]
-'scopeName': 'text.restructuredtext'
+name: "reStructuredText"
+scopeName: "text.restructuredtext"
+fileTypes: ["rst", "rest"]
+patterns: [ include: "#all" ]
+
+repository:
+	
+	all:
+		patterns: [
+			{include: "#escape"}
+			{include: "#line-blocks"}
+			{include: "#tables"}
+			{include: "#headings"}
+			{include: "#substitution-definition"}
+			{include: "#directives"}
+			{include: "#raw-blocks"}
+			{include: "#inlines"}
+			{include: "#tag-name"}
+			{include: "#doctests"}
+			{include: "#domains"}
+			{include: "#comments"}
+		]
+	
+	
+	# Inline elements: formatting, links, citations, etc
+	inlines:
+		patterns: [
+			{include: "#escape"}
+			{include: "#emphasis"}
+			{include: "#link-definition"}
+			{include: "#substitution"}
+			{include: "#literal"}
+			{include: "#interpreted-line"}
+			{include: "#anonymous-link"}
+			{include: "#link-reference"}
+			{include: "#interpreted-block"}
+			{include: "#link-text"}
+			{include: "#footnotes"}
+			{include: "#citations"}
+		]
+	
+	escape:
+		match: "\\\\."
+		name: "constant.character.escape.backslash.restructuredtext"
+	
+	
+	# Path/URL
+	uri:
+		name: "string.other.uri.restructuredtext"
+		match: "\\S+"
+		captures: 0: name: "markup.link.underline.restructuredtext"
+	
+	
+	# Numeric length values
+	length:
+		name: "constant.numeric.length.restructuredtext"
+		match: "[\\d.]+\\s*(?i:(em|ex|px|in|cm|mm|pt|pc)|(%))?"
+		captures:
+			1: name: "keyword.other.${1:/downcase}-unit.restructuredtext"
+			2: name: "keyword.other.percentile-unit.restructuredtext"
+	
+	
+	# Section border
+	headings:
+		name: "markup.heading.restructuredtext"
+		match: "^[-=~`#\"^+*:.'_]{3,}\\s*$"
+		captures:
+			0: name: "punctuation.definition.heading.restructuredtext"
+	
+	
+	# Line blocks
+	"line-blocks":
+		name: "meta.line-block.restructuredtext"
+		begin: "^(\\s*)(\\|)(?!.*?(?<=\\S)\\|)"
+		end:   "^(?=\\s*$\\n?)"
+		beginCaptures:
+			2: name: "punctuation.separator.line-block.restructuredtext"
+		patterns: [
+			{
+				match: "^\\s*(\\|)"
+				captures:
+					0: name: "punctuation.separator.line-block.restructuredtext"
+			}
+			
+			{include: "#inlines"}
+		]
+		
+	
+	# Emphasised text: bold/italics
+	emphasis:
+		patterns: [
+			
+			# Bold
+			{
+				name: "markup.bold.restructuredtext"
+				match: "(\\*\\*)[^\\*\\s][^*]*(\\*\\*)"
+				captures:
+					1: "name": "punctuation.definition.bold.restructuredtext"
+					2: "name": "punctuation.definition.bold.restructuredtext"
+			}
+			
+			# Italic
+			{
+				name: "markup.italic.restructuredtext"
+				match: "(?<!\\\\)(\\*)[^\\*\\s][^*]*(?<!\\\\)(\\*)"
+				captures:
+					1: name: "punctuation.definition.italic.restructuredtext"
+					2: name: "punctuation.definition.italic.restructuredtext"
+			}
+		]
+	
+	
+	# Inline literal
+	literal:
+		name: "markup.raw.restructuredtext"
+		begin: "``"
+		end:   "``((?=[^`\\w\\d])|$)"
+		captures:
+			0: name: "punctuation.definition.raw.restructuredtext"
+	
+	
+	# Intepreted text: Multiline with role
+	"interpreted-block":
+		name: "markup.other.command.restructuredtext"
+		contentName: "string.other.interpreted.restructuredtext"
+		begin: "(:)([-A-z0-9:_.]*)(:)(`)"
+		end:   "(`)"
+		beginCaptures:
+			1: name: "punctuation.definition.intepreted.restructuredtext"
+			2: name: "entity.name.role.restructuredtext"
+			3: name: "punctuation.definition.intepreted.restructuredtext"
+			4: name: "punctuation.definition.intepreted.restructuredtext"
+		endCaptures:
+			1: name: "punctuation.definition.intepreted.restructuredtext"
+	
+	
+	# Intepreted text: Single line
+	"interpreted-line":
+		name: "markup.other.command.restructuredtext"
+		match: "(`)[^`]+(`)(?!_)"
+		captures:
+			1: name: "punctuation.definition.intepreted.restructuredtext"
+			2: name: "punctuation.definition.intepreted.restructuredtext"
+	
+	
+	# Anonymous links: url__
+	"anonymous-link":
+		name: "meta.link.restructuredtext"
+		match: "\\s*(__)\\s+(.+)"
+		captures:
+			1: name: "punctuation.definition.link.restructuredtext"
+			2: name: "markup.underline.link.restructuredtext"
+	
+
+	# Links: `text`_ 
+	"link-text":
+		name: "meta.link.inline.restructuredtext"
+		match: "(`)([^<`]+)\\s+(<)(.*?)(>)(`_)"
+		captures:
+			1: name: "punctuation.definition.link.restructuredtext"
+			2: name: "string.other.link.title.restructuredtext"
+			3: name: "punctuation.definition.location.restructuredtext"
+			4: name: "markup.underline.link.restructuredtext"
+			5: name: "punctuation.definition.location.restructuredtext"
+			6: name: "punctuation.definition.link.restructuredtext"
+	
+	
+	
+	citations:
+		patterns: [
+			
+			# Replacement
+			{
+				name: "meta.link.citation.def.restructuredtext"
+				match: "^(\\.\\.)\\s+((\\[)[A-z][A-z0-9]*(\\]))(_)\\s+(.*)"
+				captures:
+					1: name: "punctuation.definition.link.restructuredtext"
+					2: name: "constant.other.citation.link.restructuredtext"
+					3: name: "punctuation.definition.constant.restructuredtext"
+					4: name: "punctuation.definition.constant.restructuredtext"
+					5: name: "punctuation.definition.constant.restructuredtext"
+					6: name: "string.other.citation.restructuredtext"
+			}
+			
+			# Citation reference
+			{
+				name: "meta.link.citation.restructuredtext"
+				match: "((\\[)[A-z][A-z0-9_-]*(\\]))(_)"
+				captures:
+					1: name: "constant.other.citation.link.restructuredtext"
+					2: name: "punctuation.definition.constant.restructuredtext"
+					3: name: "punctuation.definition.constant.restructuredtext"
+					4: name: "punctuation.definition.constant.restructuredtext"
+			}
+		]
+	
+	
+	
+	comments:
+		patterns: [
+			
+			# Kludge to match empty/unindented block-comments
+			{
+				name:  "comment.block.empty-start.double-dot.restructuredtext"
+				begin: "^(\\.\\.)[\\t ]*$\\n?"
+				end:   "^(?<=\\G)\\s*$\\n?|^(?=\\S)"
+				beginCaptures:
+					1: name: "punctuation.definition.comment.restructuredtext"
+				patterns: [
+					# This exists to stop FirstMate ending too early
+					begin: "^(\\s+).*?\\S+\\s*$\\n"
+					end:   "^\\s*$\\n|^(?=\\S)"
+				]
+			}
+			
+			
+			# Kludge to match (most) indented block-comments
+			{
+				name: "comment.block.empty-start.double-dot.restructuredtext"
+				begin: "^([\\t ]*)(\\.\\.)[\\t ]*$\\n?"
+				end:   "^(?!\\1\\s*\\S)|^(?<!\\G)\\s*$\\n?|^(?=\\S)"
+				beginCaptures:
+					2: name: "punctuation.definition.comment.restructuredtext"
+				patterns: [
+					begin: "^(\\s+).*?\\S+\\s*$\\n"
+					end:   "^\\s*$\\n|^\\s*(?=\\S)"
+				]
+			}
+			
+			
+			# Every other comment with text on the starting line
+			{
+				name: "comment.block.double-dot.restructuredtext"
+				begin: "^(\\s*)(\\.\\.)(?=\\s|$)"
+				end:   "^(?!\\1[\\t\\s]+\\S|\\s*$)|^(?=\\S)"
+				beginCaptures:
+					2: name: "punctuation.definition.comment.restructuredtext"
+			}
+		]
+	
+
+
+	
+	
+	footnotes:
+		patterns: [
+			
+			# Definition
+			{
+				name: "meta.link.footnote.def.restructuredtext"
+				begin: "^(\\s*)(\\.\\.)\\s+((\\[)(((#?)[^\\]]*?)|\\*)(\\]))\\s+"
+				end:   "^(?!\\s*$|\\1[ \\t]+\\S)"
+				patterns: [include: "#inlines"]
+				contentName: "string.other.footnote.restructuredtext"
+				captures:
+					2: name: "punctuation.definition.link.restructuredtext"
+					3: name: "constant.other.footnote.link.restructuredtext"
+					4: name: "punctuation.definition.constant.restructuredtext"
+					7: name: "punctuation.definition.constant.restructuredtext"
+					8: name: "punctuation.definition.constant.restructuredtext"
+			}
+			
+			# Reference: [0]_
+			{
+				name: "meta.link.footnote.numeric.restructuredtext"
+				match: "((\\[)[0-9]+(\\]))(_)"
+				captures:
+					1: name: "constant.other.footnote.link"
+					2: name: "punctuation.definition.constant.restructuredtext"
+					3: name: "punctuation.definition.constant.restructuredtext"
+					4: name: "punctuation.definition.constant.restructuredtext"
+			}
+			
+			# Reference: [#]_ or [#foo]_
+			{
+				name: "meta.link.footnote.auto.restructuredtext"
+				match: "((\\[#)[A-z0-9_]*(\\]))(_)"
+				captures:
+					1: name: "constant.other.footnote.link"
+					2: name: "punctuation.definition.constant.restructuredtext"
+					3: name: "punctuation.definition.constant.restructuredtext"
+					4: name: "punctuation.definition.constant.restructuredtext"
+			}
+			
+			# Reference: [*]_
+			{
+				name: "meta.link.footnote.symbol.auto.restructuredtext"
+				match: "((\\[)\\*(\\]))(_)"
+				captures:
+					1: name: "constant.other.footnote.link.restructuredtext"
+					2: name: "punctuation.definition.constant.restructuredtext"
+					3: name: "punctuation.definition.constant.restructuredtext"
+					4: name: "punctuation.definition.constant.restructuredtext"
+			}
+		]
+	
+	
+	
+	"link-definition":
+		patterns: [
+			{
+				name: "meta.link.reference.def.restructuredtext"
+				match: "(\\.\\.)\\s+(_)([-.\\d\\w\\s()/]+)(:)\\s+(.*)"
+				captures:
+					1: name: "punctuation.definition.link.restructuredtext"
+					2: name: "punctuation.definition.string.restructuredtext"
+					3: name: "string.other.link.title.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: patterns: [include: "#uri"]
+			}
+			
+			{
+				name: "meta.link.reference.def.restructuredtext"
+				match: "(\\.\\.)\\s+(_`)([^`]+)(`:)\\s+(.*)"
+				captures:
+					1: name: "punctuation.definition.link.restructuredtext"
+					2: name: "punctuation.definition.string.restructuredtext"
+					3: name: "string.other.link.title.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: patterns: [include: "#uri"]
+			}
+		]
+	
+	
+	"link-reference":
+		patterns: [
+			{
+				name: "meta.link.reference"
+				match: "\\b([-.:+_\\d\\w]+)(_)\\b"
+				captures:
+					1: name: "string.other.link.title.restructuredtext"
+					2: name: "punctuation.definition.link.restructuredtext"
+			}
+			
+			{
+				name: "meta.link.reference"
+				begin: "(`)"
+				end:   "(`_)"
+				beginCaptures: 1: name: "punctuation.definition.link.restructuredtext"
+				endCaptures:   1: name: "punctuation.definition.link.restructuredtext"
+				patterns: [
+					name: "string.other.link.title.restructuredtext"
+					match: "[^`]+"
+				]
+			}
+		]
+	
+	
+	# Literal Blocks
+	"raw-blocks":
+		contentName: "meta.raw.block.restructuredtext"
+		patterns: [name: "markup.raw.inner.restructuredtext", match: ".+"]
+		begin: "^(?!\\s*\\.\\.\\s\\w+)(\\s*)(.*)(::)$"
+		end:   "^(?!\\s*$|\\1[ \\t]+\\S)"
+		beginCaptures:
+			2: patterns: [include: "#inlines"]
+			3: name: "punctuation.section.raw.restructuredtext"
+
+
+	# Interactive Python sessions
+	doctests:
+		name: "meta.doctest.restructuredtext"
+		begin: "^(\\s*)(>>>)\\s+(.*)$\\n"
+		end:   "^\\s*$|^(?=\\1>>> )|^(?=>>>)|^(?!\\1)\\s+\\S"
+		contentName: "markup.raw.restructuredtext"
+		beginCaptures:
+			2: name: "punctuation.separator.prompt.doctest.restructuredtext"
+			3: patterns: [include: "source.python"]
+
+
+	# Tables
+	tables:
+		patterns: [
+			
+			# Grid tables
+			{
+				name: "meta.table.grid-table.restructuredtext"
+				contentName: "markup.other.table.restructuredtext"
+				begin: "(?=((\\+-[+-]+))|((\\+=[+=]+))\\s*$)"
+				end:   "^\\s*$"
+				patterns: [
+					{include: "#table-borders"}
+					{include: "#inlines"}
+				]
+			}
+			
+			# Simple tables
+			{
+				name: "punctuation.definition.table.simple-divider.restructuredtext"
+				match: """(?x)
+					^\\s*-{2,}\\s+-{2,}(?:\\s+-{2,})*\\s*$
+					|
+					^\\s*={2,}\\s+={2,}(?:\\s+={2,})*\\s*$
+				"""
+			}
+		]
+
+	
+	# Row and column dividers
+	"table-borders":
+		patterns: [
+			{
+				begin: "\\+(?=-+(?=\\+|$))"
+				end:   "(?=\\+(?=-)|$)|\\+(?=\\s|$)"
+				contentName: "punctuation.definition.table.row-divider.restructuredtext"
+				beginCaptures: 0: name: "punctuation.definition.table.joint.restructuredtext"
+				endCaptures:   0: name: "punctuation.definition.table.joint.restructuredtext"
+			}
+			
+			{
+				begin: "\\+(?==+(?=\\+|$))"
+				end:   "(?=\\+(?==)|$)|\\+\\s*$"
+				contentName: "punctuation.definition.table.header.row-divider.restructuredtext"
+				beginCaptures: 0: name: "punctuation.definition.table.joint.restructuredtext"
+				endCaptures:   0: name: "punctuation.definition.table.joint.restructuredtext"
+			}
+			
+			{
+				match: "\\|"
+				name: "punctuation.definition.table.header.column-divider.restructuredtext"
+			}
+		]
+	
+	# Named tag/field
+	"tag-name":
+		name: "entity.name.tag.restructuredtext"
+		match: "(:)[A-Za-z][\\w\\s=.]*(:)"
+		captures:
+			1: "name": "punctuation.definition.field.restructuredtext"
+			2: "name": "punctuation.definition.field.restructuredtext"
+
+
+	substitution:
+		name: "support.variable.substitution.restructuredtext"
+		match: "(?<!\\\\)(\\|)[^|]+(?<!\\\\)(\\|_{0,2})"
+		captures:
+			1: name: "punctuation.definition.substitution.restructuredtext"
+			2: name: "punctuation.definition.substitution.restructuredtext"
+
+	
+	"substitution-definition":
+		patterns: [
+			
+			# Image substitution
+			{
+				name: "meta.substitution-definition.image.restructuredtext"
+				begin: "^(\\s*)(\\.\\.)\\s(\\|)(?=\\S)([^\\|]+)((?<=\\S)\\|)\\s+(image)(::)\\s*(\\S+)"
+				end:   "^(?!\\s*$|\\1[ \\t]+\\S)"
+				patterns: [include: "#image-options"]
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "punctuation.definition.substitution.start.restructuredtext"
+					4: name: "entity.name.substitution.restructuredtext"
+					5: name: "punctuation.definition.substitution.end.restructuredtext"
+					6: name: "support.directive.restructuredtext"
+					7: name: "punctuation.separator.key-value.restructuredtext"
+					8: patterns: [include: "#uri"]
+			}
+			
+			
+			# Generic/custom definition
+			{
+				name: "meta.substitution-definition.restructuredtext"
+				begin: "^(\\s*)(\\.\\.)\\s(\\|)(?=\\S)([^\\|]+)((?<=\\S)\\|)\\s+(\\S+.*(?=::))(::)(.*)"
+				end:   "^(?!\\s*$|\\1[ \\t]+\\S)"
+				patterns: [include: "#directive-options"]
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "punctuation.definition.substitution.start.restructuredtext"
+					4: name: "entity.name.substitution.restructuredtext"
+					5: name: "punctuation.definition.substitution.end.restructuredtext"
+					6: name: "support.directive.restructuredtext"
+					7: name: "punctuation.separator.key-value.restructuredtext"
+					8: name: "string.unquoted.substitution.data.restructuredtext"
+			}
+		]
+	
+
+	directives:
+		patterns: [
+			
+			# Image
+			{
+				name: "meta.image.restructuredtext"
+				begin: "^(\\s*)(\\.\\.)\\s(image)(::)\\s*(\\S+)"
+				end:   "^(?!\\s*$|\\1[ \\t]+\\S)"
+				patterns: [include: "#image-options"]
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "support.directive.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: patterns: [include: "#uri"]
+			}
+			
+			# Figure
+			{
+				name: "meta.figure.restructuredtext"
+				begin: "^(\\s*)(\\.\\.)\\s(figure)(::)\\s*(\\S+)"
+				end:   "^(?!\\s*$|\\1[ \\t]+\\S)"
+				patterns: [
+					{include: "#image-options"}
+					{include: "#all"}
+				]
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "support.directive.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: patterns: [include: "#uri"]
+			}
+			
+			# HTML
+			{
+				begin: "^([ \\t]*)(\\.\\.)\\s(raw)(::)\\s+(html)\\s*$"
+				end:   "^(?!\\1[ \\t])"
+				patterns: [include: "text.html.basic"]
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "support.directive.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: name: "entity.name.directive.restructuredtext"
+			}
+			
+			# CoffeeScript
+			{
+				contentName: "source.embedded.coffee"
+				patterns: [include: "source.coffee"]
+				begin: "^([ \\t]*)(\\.\\.)\\s(code(?:-block)?)(::)\\s+(coffee-?script)\\s*$"
+				end:   "^(?!\\s*$|\\1[ \\t]+\\S)"
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "support.directive.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: name: "entity.name.directive.restructuredtext"
+			}
+			
+			# JavaScript
+			{
+				contentName: "source.embedded.js"
+				patterns: [include: "source.js"]
+				begin: "^([ \\t]*)(\\.\\.)\\s(code(?:-block)?)(::)\\s+(js|javascript)\\s*$"
+				end:   "^(?!\\s*$|\\1[ \\t]+\\S)"
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "support.directive.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: name: "entity.name.directive.restructuredtext"
+			}
+			
+			# JSON
+			{
+				contentName: "source.embedded.json"
+				patterns: [include: "source.json"]
+				begin: "^([ \\t]*)(\\.\\.)\\s(code(?:-block)?)(::)\\s+(json)\\s*$"
+				end:   "^(?!\\s*$|\\1[ \\t]+\\S)"
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "support.directive.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: name: "entity.name.directive.restructuredtext"
+			}
+			
+			# CSS
+			{
+				contentName: "source.embedded.css"
+				patterns: [include: "source.css"]
+				begin: "^([ \\t]*)(\\.\\.)\\s(code(?:-block)?)(::)\\s+(css)\\s*$"
+				end:   "^(?!\\s*$|\\1[ \\t]+\\S)"
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "support.directive.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: name: "entity.name.directive.restructuredtext"
+			}
+			
+			# XML
+			{
+				contentName: "source.embedded.xml"
+				patterns: [include: "source.xml"]
+				begin: "^([ \\t]*)(\\.\\.)\\s(code(?:-block)?)(::)\\s+(xml)\\s*$"
+				end:   "^(?!\\s*$|\\1[ \\t]+\\S)"
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "support.directive.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: name: "entity.name.directive.restructuredtext"
+			}
+			
+			# Ruby
+			{
+				contentName: "source.embedded.ruby"
+				patterns: [include: "source.ruby"]
+				begin: "^([ \\t]*)(\\.\\.)\\s(code(?:-block)?)(::)\\s+(ruby)\\s*$"
+				end:   "^(?!\\s*$|\\1[ \\t]+\\S)"
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "support.directive.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: name: "entity.name.directive.restructuredtext"
+			}
+			
+			# Java
+			{
+				contentName: "source.embedded.java"
+				patterns: [include: "source.java"]
+				begin: "^([ \\t]*)(\\.\\.)\\s(code(?:-block)?)(::)\\s+(java)\\s*$"
+				end:   "^(?!\\s*$|\\1[ \\t]+\\S)"
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "support.directive.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: name: "entity.name.directive.restructuredtext"
+			}
+			
+			# Erlang
+			{
+				contentName: "source.embedded.erlang"
+				patterns: [include: "source.erlang"]
+				begin: "^([ \\t]*)(\\.\\.)\\s(code(?:-block)?)(::)\\s+(erlang)\\s*$"
+				end:   "^(?!\\s*$|\\1[ \\t]+\\S)"
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "support.directive.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: name: "entity.name.directive.restructuredtext"
+			}
+			
+			# C-sharp/C#
+			{
+				contentName: "source.embedded.cs"
+				patterns: [include: "source.cs"]
+				begin: "^([ \\t]*)(\\.\\.)\\s(code(?:-block)?)(::)\\s+(csharp|c#)\\s*$"
+				end:   "^(?!\\s*$|\\1[ \\t]+\\S)"
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "support.directive.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: name: "entity.name.directive.restructuredtext"
+			}
+			
+			# PHP
+			{
+				contentName: "source.embedded.php"
+				patterns: [include: "source.php"]
+				begin: "^([ \\t]*)(\\.\\.)\\s(code(?:-block)?)(::)\\s+(php[3-5]?)\\s*$"
+				end:   "^(?!\\s*$|\\1[ \\t]+\\S)"
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "support.directive.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: name: "entity.name.directive.restructuredtext"
+			}
+			
+			# Shell
+			{
+				contentName: "source.embedded.shell"
+				patterns: [include: "source.shell"]
+				begin: "^([ \\t]*)(\\.\\.)\\s(code(?:-block)?)(::)\\s+(shell|(ba|k)?sh)\\s*$"
+				end:   "^(?!\\s*$|\\1[ \\t]+\\S)"
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "support.directive.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: name: "entity.name.directive.restructuredtext"
+			}
+			
+			# Python/Sage
+			{
+				contentName: "source.embedded.python"
+				patterns: [include: "source.python"]
+				begin: "^([ \\t]*)(\\.\\.)\\s(code(?:-block)?)(::)\\s+(py(thon)?|sage)\\s*$"
+				end:   "^(?!\\s*$|\\1[ \\t]+\\S)"
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "support.directive.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: name: "entity.name.directive.restructuredtext"
+			}
+			
+			# Objective-C
+			{
+				contentName: "source.embedded.objc"
+				patterns: [include: "source.objc"]
+				begin: "^([ \\t]*)(\\.\\.)\\s(code(?:-block)?)(::)\\s+(objective-?c|obj-?c)\\s*$"
+				end:   "^(?!\\s*$|\\1[ \\t]+\\S)"
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "support.directive.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: name: "entity.name.directive.restructuredtext"
+			}
+			
+			# YAML
+			{
+				contentName: "source.embedded.yaml"
+				patterns: [include: "source.yaml"]
+				begin: "^([ \\t]*)(\\.\\.)\\s(code(?:-block)?)(::)\\s+(yaml)\\s*$"
+				end:   "^(?!\\s*$|\\1[ \\t]+\\S)"
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "support.directive.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: name: "entity.name.directive.restructuredtext"
+			}
+			
+			# Directives
+			{
+				name: "meta.other.directive.restructuredtext"
+				match: "(\\.\\.)\\s([A-z][-A-z0-9_]+)(::)\\s*$"
+				captures:
+					1: name: "punctuation.definition.directive.restructuredtext"
+					2: name: "support.directive.restructuredtext"
+					3: name: "punctuation.separator.key-value.restructuredtext"
+			}
+			
+			
+			# Directives with arguments
+			{
+				name: "meta.other.directive.restructuredtext"
+				match: "(\\.\\.)\\s([A-z][-A-z0-9_]+)(::)\\s+(.+?)\\s*$"
+				captures:
+					1: name: "punctuation.definition.directive.restructuredtext"
+					2: name: "support.directive.restructuredtext"
+					3: name: "punctuation.separator.key-value.restructuredtext"
+					4: name: "entity.name.directive.restructuredtext"
+			}
+		]
+
+
+
+	# Optional :attribute: statements found underneath some directives
+	"directive-options":
+		patterns: [
+			name: "meta.directive-option.restructuredtext"
+			match: "(:[^:]+:)\\s*(.*)"
+			captures:
+				1: patterns: [include: "#tag-name"]
+				2: name: "string.other.tag-value.restructuredtext"
+		]
+
+
+	# Image parameters (width/height, etc)
+	"image-options":
+		patterns: [
+			
+			# Alt text
+			{
+				name: "meta.image-option.alt.restructuredtext"
+				match: "(:alt:)\\s*(.*)"
+				captures:
+					1: patterns: [include: "#tag-name"]
+					2: name: "string.other.tag-value.restructuredtext"
+			}
+			
+			# Height
+			{
+				name: "meta.image-option.height.restructuredtext"
+				match: "(:height:)\\s*(.*)"
+				captures:
+					1: patterns: [include: "#tag-name"]
+					2: patterns: [include: "#length"]
+			}
+			
+			# Width
+			{
+				name: "meta.image-option.width.restructuredtext"
+				match: "(:width:)\\s*(.*)"
+				captures:
+					1: patterns: [include: "#tag-name"]
+					2: patterns: [include: "#length"]
+			}
+			
+			# Scale
+			{
+				name: "meta.image-option.scale.restructuredtext"
+				match: "(:scale:)\\s*(.*)"
+				captures:
+					1: patterns: [include: "#tag-name"]
+					2: patterns: [include: "#length"]
+			}
+			
+			# Align
+			{
+				name: "meta.image-option.align.restructuredtext"
+				match: "(:align:)\\s*(?:(top|middle|bottom|left|center|right)\\b)?"
+				captures:
+					1: patterns: [include: "#tag-name"]
+					2: name: "keyword.language.image-alignment.restructuredtext"
+			}
+			
+			# Target
+			{
+				name: "meta.image-option.target.restructuredtext"
+				match: "(:target:)\\s*(.*)?"
+				captures:
+					1: patterns: [include: "#tag-name"]
+					2: name: "string.other.target.restructuredtext"
+			}
+			
+			{include: "#doctree-options"}
+			{include: "#directive-options"}
+		]
+	
+	
+	
+	# Common Doctree options
+	# See: http://docutils.sourceforge.net/docs/ref/rst/directives.html#id17
+	"doctree-options":
+		patterns: [
+			
+			# Classes
+			{
+				name: "meta.doctree-option.class.restructuredtext"
+				match: "(:class:)\\s*(.*)"
+				captures:
+					1: patterns: [include: "#tag-name"]
+					2: name: "string.other.class-list.restructuredtext"
+			}
+			
+			# Name
+			{
+				name: "meta.doctree-option.name.restructuredtext"
+				match: "(:name:)\\s*(.*)"
+				captures:
+					1: patterns: [include: "#tag-name"]
+					2: name: "string.other.name.restructuredtext"
+			}
+		]
+
+
+	# Sphinx domains
+	domains:
+		patterns: [
+			
+			# Python domain
+			{
+				name: "meta.sphinx-domain.restructuredtext"
+				contentName: "source.embedded.python"
+				patterns: [include: "source.python"]
+				begin: "^(\\s*)(\\.\\.)\\s+(py)(:)([^:]+)(::)"
+				end:   "^(?!\\s*$|\\1[ \\t]{5,}\\S)"
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "support.directive.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: name: "support.directive.restructuredtext"
+					6: name: "punctuation.separator.key-value.restructuredtext"
+			}
+			
+			
+			# C domain
+			{
+				name: "meta.sphinx-domain.restructuredtext"
+				contentName: "source.embedded.c"
+				patterns: [include: "source.c"]
+				begin: "^(\\s*)(\\.\\.)\\s+(c)(:)([^:]+)(::)"
+				end:   "^(?!\\s*$|\\1[ \\t]{5,}\\S)"
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "support.directive.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: name: "support.directive.restructuredtext"
+					6: name: "punctuation.separator.key-value.restructuredtext"
+			}
+			
+			
+			# C++ domain
+			{
+				name: "meta.sphinx-domain.restructuredtext"
+				begin: "^(\\s*)(\\.\\.)\\s+(cpp)(::?)([^:]+)(::)"
+				end:   "^(?!\\s*$|\\1[ \\t]{5,}\\S)"
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "support.directive.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: name: "support.directive.restructuredtext"
+					6: name: "punctuation.separator.key-value.restructuredtext"
+				
+				# This is a hack to stop C++ syntax spilling out of control
+				patterns: [
+					match: "(.+)(\\\\?)$"
+					captures:
+						1: name: "source.embedded.cpp", patterns: [include: "source.cpp"]
+						2: name: "constant.character.escape.newline.restructuredtext"
+				]
+			}
+			
+			
+			# JavaScript domain
+			{
+				name: "meta.sphinx-domain.restructuredtext"
+				begin: "^(\\s*)(\\.\\.)\\s+(js)(:)([^:]+)(::)"
+				end:   "^(?!\\s*$|\\1[ \\t]{5,}\\S)"
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "support.directive.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: name: "support.directive.restructuredtext"
+					6: name: "punctuation.separator.key-value.restructuredtext"
+				
+				# JS syntax might go haywire too: expect its grammar to change at any time
+				patterns: [
+					match: "(.+)(\\\\?)$"
+					captures:
+						1: name: "source.embedded.js", patterns: [include: "source.js"]
+						2: name: "constant.character.escape.newline.restructuredtext"
+				]
+			}
+			
+			
+			# Anything else
+			{
+				name: "meta.sphinx-domain.restructuredtext"
+				contentName: "string.unquoted.domain.restructuredtext"
+				begin: "^(\\s*)(\\.\\.)\\s+([^:]+)(::?)([^:]+)(::)"
+				end:   "^(?!\\s*$|\\1[ \\t]{5,}\\S)"
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "support.directive.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: name: "support.directive.restructuredtext"
+					6: name: "punctuation.separator.key-value.restructuredtext"
+			}
+		]

--- a/grammars/restructuredtext.cson
+++ b/grammars/restructuredtext.cson
@@ -6,7 +6,11 @@
 'name': 'reStructuredText'
 'patterns': [
   {
-    'begin': '^([ \\t]*)(?=\\S)'
+    'include': '#block-comments'
+  }
+  
+  {
+    'begin': '^([ \\t]*)(?!\\.\\.)(?=\\S)'
     'contentName': 'meta.paragraph.restructuredtext'
     'end': '^(?!\\1)'
     'patterns': [
@@ -171,15 +175,53 @@
         'name': 'meta.link.citation.restructuredtext'
       }
     ]
-  'comments':
+  'block-comments':
     'patterns': [
       {
-        'begin': '^(\\.\\.)[ ]'
+        'name': 'comment.block.empty-start.double-dot.restructuredtext'
+        'begin': '^(\\.\\.)[\\t ]*$\\n?'
+        'end': "^(?<=\\G)\\s*$\\n?|^(?=\\S)"
         'beginCaptures':
           '1':
             'name': 'punctuation.definition.comment.restructuredtext'
-        'end': '^[\\s]*$\\n?'
-        'name': 'comment.line.double-dot.restructuredtext'
+        'patterns': [
+          {
+            'begin': "^(\\s+).*?\\S+\\s*$\\n"
+            'end': "^\\s*$\\n|^(?=\\S)"
+          }
+        ]
+      }
+      
+      {
+        'name': 'comment.block.empty-start.double-dot.restructuredtext'
+        'begin': '^([\\t ]*)(\\.\\.)[\\t ]*$\\n?'
+        'end': "^(?!\\1\\s*\\S)|^(?<!\\G)\\s*$\\n?|^(?=\\S)"
+        'beginCaptures':
+          '2':
+            'name': 'punctuation.definition.comment.restructuredtext'
+        'patterns': [
+          {
+            'begin': "^(\\s+).*?\\S+\\s*$\\n"
+            'end': "^\\s*$\\n|^\\s*(?=\\S)"
+          }
+        ]
+      }
+      
+      {
+        'name': 'comment.block.double-dot.restructuredtext'
+        'begin': '^(\\s*)(\\.\\.)(?=\\s|$)'
+        'end': '^(?!\\s*$|\\1[ \\t]+\\S)'
+      }
+    ]
+  'comments':
+    'patterns': [
+      {
+        'begin': "^([\\t ]*)(\\.\\.)(?=\\s|$)"
+        'end': "^(?!\\1[\\t\\s]+\\S|\\s*$)|^(?=\\S)"
+        'beginCaptures':
+          '2':
+            'name': 'punctuation.definition.comment.restructuredtext'
+        'name': "comment.block.double-dot.restructuredtext"
       }
     ]
   'directives':

--- a/grammars/restructuredtext.cson
+++ b/grammars/restructuredtext.cson
@@ -686,4 +686,4 @@
         'name': 'entity.name.tag.restructuredtext'
       }
     ]
-'scopeName': 'text.restructuredtext source.gfm.restructuredtext'
+'scopeName': 'text.restructuredtext'

--- a/grammars/restructuredtext.cson
+++ b/grammars/restructuredtext.cson
@@ -705,7 +705,7 @@ repository:
 			# Directives
 			{
 				name: "meta.other.directive.restructuredtext"
-				match: "(\\.\\.)\\s([A-z][-A-z0-9_]+)(::)\\s*$"
+				match: "^\\s*(\\.\\.)\\s([A-z][-A-z0-9_]+)(::)\\s*$"
 				captures:
 					1: name: "punctuation.definition.directive.restructuredtext"
 					2: name: "support.directive.restructuredtext"
@@ -716,7 +716,7 @@ repository:
 			# Directives with arguments
 			{
 				name: "meta.other.directive.restructuredtext"
-				match: "(\\.\\.)\\s([A-z][-A-z0-9_]+)(::)\\s+(.+?)\\s*$"
+				match: "^\\s*(\\.\\.)\\s([A-z][-A-z0-9_]+)(::)\\s+(.+?)\\s*$"
 				captures:
 					1: name: "punctuation.definition.directive.restructuredtext"
 					2: name: "support.directive.restructuredtext"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "language-restructuredtext",
   "version": "0.15.0",
   "private": true,
-  "description": "RestructuredText Language Support",
+  "keywords": ["reStructuredText", "reStructured Text", "rst", "reST", "Docutils", "Python"],
+  "description": "Add snippets and syntax highlighting for reStructuredText files",
   "repository": "https://github.com/Lukasa/language-restructuredtext",
   "license": "MIT",
   "engines": {

--- a/settings/language-restructuredtext.cson
+++ b/settings/language-restructuredtext.cson
@@ -1,4 +1,4 @@
-'.text.restructuredtext, .source.gfm.restructuredtext':
+'.text.restructuredtext':
   'editor':
     'commentStart': '.. '
     'increaseIndentPattern': '::\\s*$'

--- a/snippets/language-restructuredtext.cson
+++ b/snippets/language-restructuredtext.cson
@@ -16,4 +16,4 @@
     'body': '${1:subsection name}\n----------------$0\n'
   'code block':
     'prefix': 'code'
-    'body': '.. code-block::\n\n\t$1'
+    'body': '.. code-block:: ${1:language}\n\n\t${2:<code>}'

--- a/snippets/language-restructuredtext.cson
+++ b/snippets/language-restructuredtext.cson
@@ -1,4 +1,4 @@
-'.text.restructuredtext, .source.gfm.restructuredtext':
+'.text.restructuredtext':
   'image':
     'prefix': 'image'
     'body': '.. image:: ${1:path}\n$0'

--- a/snippets/language-restructuredtext.cson
+++ b/snippets/language-restructuredtext.cson
@@ -14,3 +14,6 @@
   'section 3':
     'prefix': 'sss'
     'body': '${1:subsection name}\n----------------$0\n'
+  'code block':
+    'prefix': 'code'
+    'body': '.. code-block::\n\n\t$1'

--- a/tests/code.rst
+++ b/tests/code.rst
@@ -1,0 +1,104 @@
+.. raw:: html
+	
+	<!DOCTYPE html>
+	<head>
+	</head>
+	</html>
+
+
+.. code-block:: coffeescript
+	
+	unless disabled? then run.something()
+
+
+
+.. code-block:: js
+	
+	Math.max()
+
+
+
+.. code-block:: json
+	
+	{
+		invalid: "value"
+	}
+
+
+.. code-block:: css
+	
+	@media (max-width: 31.5em){
+		#page{
+			color: #000 !important;
+		}
+	}
+
+
+.. code-block:: xml
+
+	<xml>
+		<!-- Comment -->
+	</xml>
+
+
+.. code-block:: ruby
+	
+	something << added
+
+
+.. code-block:: java
+
+	class Dismissed{
+		public function blah(){
+			
+		}
+	}
+
+
+.. code-block:: erlang
+
+	%% I don't know this language, kek
+
+.. code-block:: csharp
+
+	class Dismissed{
+		public function blah(){
+			
+		}
+	}
+
+
+.. code-block:: php
+	
+	min()
+
+
+.. code-block:: sh
+
+	#!/bin/sh
+	set +o posix
+	cd ~;
+
+
+.. code-block:: python
+
+	import crap from somewhere
+
+
+.. code:: python
+	
+	print "Probando la mierda esta"
+
+
+.. code-block:: obj-c
+
+	[ NSSet something:useful ]
+
+
+.. code-block:: yaml
+
+	key: value
+	list:
+	- one
+	- two
+	- three

--- a/tests/directives.rst
+++ b/tests/directives.rst
@@ -1,0 +1,115 @@
+.. image:: /images/heart.png
+   :alt: Alternate text
+   :height: 11px
+   :width: 11em
+   :scale: 50 %
+   :align: top
+   :target: text
+
+.. |H| image:: /images/heart.png
+   :alt: Alternate text
+   :height: 11px
+   :width: 11em
+   :scale: 50 %
+   :align: top
+   :target: text
+
+
+The |biohazard| symbol must be used on containers used to
+dispose of medical waste.
+
+.. |biohazard| image:: biohazard.png
+
+
+|Michael| and |Jon| are our widget-wranglers.
+
+.. |Michael| user:: mjones
+.. |Jon|     user:: jhl
+
+
+|The Transparent Society| offers a fascinating alternate view
+on privacy issues.
+
+.. |The Transparent Society| book:: isbn=0738201448
+
+
+4XSLT has the convenience method |runString|, so you don't
+have to mess with DOM objects if all you want is the
+transformed output.
+
+.. |runString| function:: module=xml.xslt class=Processor
+
+
+West led the |H| 3, covered by dummy's |H| Q, East's |H| K,
+and trumped in hand with the |S| 2.
+
+.. |H| image:: /images/heart.png
+   :height: 11px
+   :width: 11
+.. |S| image:: /images/spade.png
+   :height: 11
+   :width: 11
+
+* |Red light| means stop.
+* |Green light| means go.
+* |Yellow light| means go really fast.
+
+.. |Red light|    image:: red_light.png
+.. |Green light|  image:: green_light.png
+.. |Yellow light| image:: yellow_light.png
+
+|-><-| is the official symbol of POEE_.
+
+.. |-><-| image:: discord.png
+.. _POEE: http://www.poee.org/
+
+
+Even |the text in Texas| is big.
+
+.. |the text in Texas| style:: big
+
+
+Welcome back, |name|!
+
+.. |name| tal:: replace user/getUserName
+
+
+|RST|_ is a little annoying to type over and over, especially
+when writing about |RST| itself, and spelling out the
+bicapitalized word |RST| every time isn't really necessary for
+|RST| source readability.
+
+.. |RST| replace:: reStructuredText
+.. _RST: http://docutils.sourceforge.net/rst.html
+
+
+But still, that's nothing compared to a name like
+|j2ee-cas|__.
+
+.. |j2ee-cas| replace::
+   the Java `TM`:super: 2 Platform, Enterprise Edition Client
+   Access Services
+__ http://developer.java.sun.com/developer/earlyAccess/
+   j2eecas/
+
+
+
+.. figure:: picture.png
+   :scale: 50 %
+   :alt: map to buried treasure
+
+   This is the caption of the figure (a simple paragraph).
+
+   The legend consists of all elements after the caption.  In this
+   case, the legend consists of this paragraph and the following
+   table:
+
+   +-----------------------+-----------------------+
+   | Symbol                | Meaning               |
+   +=======================+=======================+
+   | .. image:: tent.png   | Campground            |
+   +-----------------------+-----------------------+
+   | .. image:: waves.png  | Lake                  |
+   +-----------------------+-----------------------+
+   | .. image:: peak.png   | Mountain              |
+   +-----------------------+-----------------------+

--- a/tests/sphinx.rst
+++ b/tests/sphinx.rst
@@ -1,0 +1,103 @@
+.. py:function:: spam(eggs)
+                 ham(eggs)
+
+   Less spam, more Perl.
+
+
+.. py:function:: filterwarnings(action, message='', category=Warning, \
+                                module='', lineno=0, append=False)
+   :noindex:
+
+The function :py:func:`spam` does a similar thing.
+
+
+
+.. function:: pyfunc()
+
+   Describes a Python function.
+
+Reference to :func:`pyfunc`.
+
+
+
+.. py:function:: send_message(sender, recipient, message_body, [priority=1])
+
+   Send a message to a recipient
+
+   :param str sender: The person sending the message
+   :param str recipient: The recipient of the message
+   :param str message_body: The body of the message
+   :param priority: The priority of the message, can be a number 1-5
+   :type priority: integer or None
+   :return: the message id
+   :rtype: int
+   :raises ValueError: if the message_body exceeds 160 characters
+   :raises TypeError: if the message_body is not a basestring
+
+
+.. c:member:: PyObject* PyTypeObject.tp_bases
+
+
+.. cpp:class:: template<typename T, std::size_t N> \
+               std::array
+
+.. cpp::class:: template<> \
+                std::array<bool, 256>
+
+.. cpp::class:: template<typename T> \
+                std::array<T, 42>
+
+.. cpp:function:: bool myMethod(int arg1, std::string arg2)
+
+
+.. cpp:function:: bool myMethod(int, double)
+
+   A function with unnamed parameters.
+
+.. cpp:function:: const T &MyClass::operator[](std::size_t i) const
+
+   An overload for the indexing operator.
+
+.. cpp:function:: operator bool() const
+
+   A casting operator.
+
+.. cpp:function:: constexpr void foo(std::string &bar[2]) noexcept
+
+   A constexpr function.
+
+.. cpp:function:: MyClass::MyClass(const MyClass&) = default
+
+   A copy constructor with default implementation.
+
+
+
+.. js:function:: $.getJSON(href, callback[, errback])
+
+   :param string href: An URI to the location of the resource.
+   :param callback: Gets called with the object.
+   :param errback:
+       Gets called in case the request fails. And a lot of other
+       text so we need multiple lines.
+   :throws SomeError: For whatever reason in that case.
+   :returns: Something.
+
+
+.. js:class:: MyAnimal(name[, age])
+
+   :param string name: The name of the animal
+   :param number age: an optional age for the animal
+
+
+.. rst:directive:: foo
+
+   Foo description.
+
+.. rst:directive:: .. bar:: baz
+
+   Bar description.
+
+
+.. rst:role:: foo
+
+   Foo description.


### PR DESCRIPTION
Whoa boy... this is gonna be hard to summarise. First of all, I apologise for changing the code-style of the grammar. People probably think I exaggerate when I say I can't follow 2-space indented code. I'm not. If the tabs are an issue, I'm happy to change them back if that's what you prefer.

ANYWAY. On to what's changed:

Tables
--------
Both grid-tables and "simple" tables are now properly highlighted, which is particularly noticeable in themes which distinguish punctuation characters (e.g., [Seti](https://atom.io/themes/seti-syntax), [Duotone](https://atom.io/themes/duotone-light-syntax)).
<img src="https://cloud.githubusercontent.com/assets/2346707/15800436/cc4b6f5e-2abc-11e6-8d03-5be4a78b6a1f.png" alt="Figure 1" width="435" />
Previously, only the top border would match, and there were also highlighting problems with `|` characters. These would be matched as substitution references, which looked particularly jarring for themes which add underlines to any match using the `underline.link` scope.

Improved substitution references
-------------------------------------------
I'll let the preview describe this one...
<img src="https://cloud.githubusercontent.com/assets/2346707/15800579/707ba51e-2ac0-11e6-831a-49dc55cbfca3.png" alt="Figure 2" width="451" />

Multiline footnotes
------------------------
Only the first line of footnotes were being highlighted. That's been fixed:
<img src="https://cloud.githubusercontent.com/assets/2346707/15800485/7e91dc92-2abe-11e6-8ad8-8b763f951332.png" alt="Figure 3" width="496" />

Sphinx domains
---------------------
An issue brought up in #13, sitting unattended for over a year. Took care of it, even going as far as including embedded syntax highlighting for each [language domain that Sphinx supports](http://www.sphinx-doc.org/en/stable/domains.html):
<img src="https://cloud.githubusercontent.com/assets/2346707/15800609/38942954-2ac1-11e6-844d-1be60d58004c.png" alt="Figure 4" width="541" />
As Sphinx allows [domains to be added](http://www.sphinx-doc.org/en/stable/domains.html#more-domains) via extensions, I left generic support for those languages which aren't defined. So `.. foobazmatron:function::` wouldn't be highlighted as a comment.

Multiline comments
-------------------------
These weren't being picked up previously either:
<img src="https://cloud.githubusercontent.com/assets/2346707/15800643/04872ad4-2ac2-11e6-85ce-8682bfa05a8b.png" alt="Figure 5" width="461" />

#### Known limitation:
[Empty comments](http://docutils.sourceforge.net/docs/user/rst/quickref.html#comments) that have a blank line directly afterward are used as "terminators" for things like nested block-quotes and stuff. There's no way of supporting this without breaking support for multiple paragraphs in comment-blocks. I brought this up in a more [technical discussion here](https://discuss.atom.io/t/multiline-firstmate-pattern-matching/29598).

So at the moment, indented paragraphs that follow an empty comment are incorrectly highlighted. This might be an edge issue, but if anybody reports it, this PR is where to send them for an explanation why a fix can't be done.

Line blocks
---------------
Like tables, this isn't really of importance unless your theme highlights punctuation characters.
<img src="https://cloud.githubusercontent.com/assets/2346707/15800676/52b757d2-2ac3-11e6-94d4-dc982f811a50.png" alt="Figure 6" width="497" />

Fixed code-block highlighting
---------------------------------------
Admittedly, this was my fault for not picking up on this in [my first PR](https://github.com/Lukasa/language-restructuredtext/pull/38) - `.. code-block:: python` and the like weren't being formatted as directive statements. Fixed that:
<img src="https://cloud.githubusercontent.com/assets/2346707/15800708/1f0f3480-2ac4-11e6-8b99-2cc3a667ced2.png" alt="Figure 7" width="486" />

Numerous other fixes
-----------------------------
* Added highlighting for escaped characters (e.g., `\|`)
* Added `code` snippet to insert a `.. code-block` statement
* Added support for [`.. code`](http://docutils.sourceforge.net/docs/ref/rst/directives.html#code) directives
* Improved wording of readme and added related links and `package.json` keywords
* Probably other stuff I missed

Issues fixed
---------------
* __Closes #34:__ Add rst / rest to the description in Atom
* __Closes #20__: Choice of scope
* __Closes #30__: Incomplete support for section underlines
* __Closes #13__: Directives with domains names are not parsed correctly
* __Closes #35__: Autocompletion
