### PR TITLE
Allow dash `-` when matching tag names.

### DIFF
--- a/grammars/restructuredtext.cson
+++ b/grammars/restructuredtext.cson
@@ -425,7 +425,7 @@ repository:
 	# Named tag/field
 	"tag-name":
 		name: "entity.name.tag.restructuredtext"
-		match: "(:)[A-Za-z][\\w\\s=.]*(:)"
+		match: "(:)[A-Za-z][\\w\\s=.-]*(:)"
 		captures:
 			1: "name": "punctuation.definition.field.restructuredtext"
 			2: "name": "punctuation.definition.field.restructuredtext"


### PR DESCRIPTION
The use of dashes is common case especially when documenting HTTP APIs
using the sphinxcontrib-httpdomain[1] extension where you document HTTP
header usage which contain dashes.

[1] https://pythonhosted.org/sphinxcontrib-httpdomain/