### PR TITLE
Allow colon and plus sign in link definition

### DIFF
--- a/grammars/restructuredtext.cson
+++ b/grammars/restructuredtext.cson
@@ -301,7 +301,7 @@ repository:
 		patterns: [
 			{
 				name: "meta.link.reference.def.restructuredtext"
-				match: "(\\.\\.)\\s+(_)([-.\\d\\w\\s()/]+)(:)\\s+(.*)"
+				match: "(\\.\\.)\\s+(_)([-.:\+\\d\\w\\s()/]+?)(:)\\s+(.*)"
 				captures:
 					1: name: "punctuation.definition.link.restructuredtext"
 					2: name: "punctuation.definition.string.restructuredtext"


### PR DESCRIPTION
Changed regex to allow colon and plus sign. Changed matching of link target name to non-greedy for proper matching of colon.
Note that I have kept the existing `\\d\\w`, although it seems superflous since `\w` already matches `[A-Za-z0-9_]`.

Fixes #50