### PR TITLE
More conservative link matching.

### DIFF
--- a/grammars/restructuredtext.cson
+++ b/grammars/restructuredtext.cson
@@ -346,14 +346,11 @@ repository:
 
 			{
 				name: "meta.link.reference"
-				begin: "`"
-				end:   "`__?"
-				beginCaptures: 0: name: "punctuation.definition.link.restructuredtext"
-				endCaptures:   0: name: "punctuation.definition.link.restructuredtext"
-				patterns: [
-					name: "string.other.link.title.restructuredtext"
-					match: "[^`]+"
-				]
+				match: "(`)(.*?)(`__?)"
+				captures:
+					1: name: "punctuation.definition.link.restructuredtext"
+					2: name: "string.other.link.title.restructuredtext"
+					3: name: "punctuation.definition.link.restructuredtext"
 			}
 		]
 

--- a/grammars/restructuredtext.cson
+++ b/grammars/restructuredtext.cson
@@ -571,6 +571,19 @@ repository:
 					5: name: "entity.name.directive.restructuredtext"
 			}
 
+			# TypeScript
+			{
+				contentName: "source.embedded.ts"
+				patterns: [include: "source.ts"]
+				begin: "^([ \\t]*)(\\.\\.)\\s(code(?:-block)?)(::)\\s+(typescript)\\s*$"
+				end:   "^(?!\\s*$|\\1[ \\t]+\\S)"
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "support.directive.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: name: "entity.name.directive.restructuredtext"
+			}
+
 			# JSON
 			{
 				contentName: "source.embedded.json"


### PR DESCRIPTION
Kind of an edge case, but including TypeScript snippets with tagged template literals previously broke the highlighting, causing everything in the file after the closing `` ` `` to be treated as a link title. This slightly more conservative match seems to cover the most common way links are used without matching them promiscuously across lines.

###### Before
![before](https://user-images.githubusercontent.com/2207980/33066304-eced57f2-ce78-11e7-8a13-0ab43fee5bc5.png)

###### After
![after](https://user-images.githubusercontent.com/2207980/33066308-f12602a6-ce78-11e7-8db7-f7c18e2488f2.png)
