### PR TITLE
Add more embedded languages

### DIFF
--- a/grammars/restructuredtext.cson
+++ b/grammars/restructuredtext.cson
@@ -725,6 +725,45 @@ repository:
 					5: name: "entity.name.directive.restructuredtext"
 			}
 
+			# IPython
+			{
+				contentName: "source.embedded.python"
+				patterns: [include: "source.python"]
+				begin: "^([ \\t]*)(\\.\\.)\\s(ipython)(::)\\s+(py(thon)?)\\s*$"
+				end:   "^(?!\\s*$|\\1[ \\t]+\\S)"
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "support.directive.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: name: "entity.name.directive.restructuredtext"
+			}
+
+			# Stata
+			{
+				contentName: "source.embedded.stata"
+				patterns: [include: "source.stata"]
+				begin: "^([ \\t]*)(\\.\\.)\\s(code(?:-block)?)(::)\\s+(stata)\\s*$"
+				end:   "^(?!\\s*$|\\1[ \\t]+\\S)"
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "support.directive.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: name: "entity.name.directive.restructuredtext"
+			}
+
+			# SAS
+			{
+				contentName: "source.embedded.python"
+				patterns: [include: "source.python"]
+				begin: "^([ \\t]*)(\\.\\.)\\s(code(?:-block)?)(::)\\s+(sas)\\s*$"
+				end:   "^(?!\\s*$|\\1[ \\t]+\\S)"
+				beginCaptures:
+					2: name: "punctuation.definition.directive.restructuredtext"
+					3: name: "support.directive.restructuredtext"
+					4: name: "punctuation.separator.key-value.restructuredtext"
+					5: name: "entity.name.directive.restructuredtext"
+			}
+
 			# Objective-C
 			{
 				contentName: "source.embedded.objc"

--- a/grammars/restructuredtext.cson
+++ b/grammars/restructuredtext.cson
@@ -547,7 +547,7 @@ repository:
 			# HTML
 			{
 				begin: "^([ \\t]*)(\\.\\.)\\s(raw)(::)\\s+(html)\\s*$"
-				end:   "^(?!\\1[ \\t])"
+				end:   "^(?!\\s*$|\\1[ \\t]+\\S)"
 				patterns: [include: "text.html.basic"]
 				beginCaptures:
 					2: name: "punctuation.definition.directive.restructuredtext"


### PR DESCRIPTION
I don't usually write in restructured text, but was adding to Pandas documentation and realized there are a few languages missing that I use often.

- `.. ipython:: python` is used to automatically run ipython code snippets upon compilation by sphinx
- `source.stata` is provided by https://atom.io/packages/language-stata
- `source.sas` is provided by https://atom.io/packages/language-sas